### PR TITLE
Allow to pass username and password for base auth in marathon url

### DIFF
--- a/main.go
+++ b/main.go
@@ -30,6 +30,10 @@ var (
 func marathonConnect(uri *url.URL) error {
 	config := marathon.NewDefaultConfig()
 	config.URL = uri.String()
+	if passwd, ok := uri.User.Password(); ok {
+		config.HTTPBasicPassword = passwd
+		config.HTTPBasicAuthUser = uri.User.Username()
+	}
 	config.HTTPClient = &http.Client{
 		Timeout: 10 * time.Second,
 		Transport: &http.Transport{


### PR DESCRIPTION
Good day, if marathon has base auth exporter will not connect to it properly. This PR fixes it.
Usage example:
marathon_exporter -marathon.uri=http://root:root@10.148.61.51:8080