### PR TITLE
Avoid race in accessing counters and gauges.

### DIFF
--- a/containers.go
+++ b/containers.go
@@ -5,6 +5,7 @@ import (
 
 	"sort"
 	"strings"
+	"sync"
 
 	"github.com/prometheus/client_golang/prometheus"
 )
@@ -20,6 +21,7 @@ const (
 type CounterContainer struct {
 	counters  map[string]*prometheus.CounterVec
 	namespace string
+	mutex     sync.Mutex
 }
 
 func NewCounterContainer(namespace string) *CounterContainer {
@@ -31,6 +33,8 @@ func NewCounterContainer(namespace string) *CounterContainer {
 
 func (c *CounterContainer) Fetch(name, help string, labels ...string) (*prometheus.CounterVec, bool) {
 	key := containerKey(name, labels)
+	c.mutex.Lock()
+	defer c.mutex.Unlock()
 	counter, exists := c.counters[key]
 
 	if !exists {
@@ -49,6 +53,7 @@ func (c *CounterContainer) Fetch(name, help string, labels ...string) (*promethe
 type GaugeContainer struct {
 	gauges    map[string]*prometheus.GaugeVec
 	namespace string
+	mutex     sync.Mutex
 }
 
 func NewGaugeContainer(namespace string) *GaugeContainer {
@@ -60,6 +65,8 @@ func NewGaugeContainer(namespace string) *GaugeContainer {
 
 func (c *GaugeContainer) Fetch(name, help string, labels ...string) (*prometheus.GaugeVec, bool) {
 	key := containerKey(name, labels)
+	c.mutex.Lock()
+	defer c.mutex.Unlock()
 	gauge, exists := c.gauges[key]
 
 	if !exists {

--- a/exporter.go
+++ b/exporter.go
@@ -81,10 +81,14 @@ func (e *Exporter) scrape(ch chan<- prometheus.Metric) {
 		return
 	}
 
+	e.Counters.mutex.Lock()
+	defer e.Counters.mutex.Unlock()
 	for _, counter := range e.Counters.counters {
 		counter.Collect(ch)
 	}
 
+	e.Gauges.mutex.Lock()
+	defer e.Gauges.mutex.Unlock()
 	for _, gauge := range e.Gauges.gauges {
 		gauge.Collect(ch)
 	}


### PR DESCRIPTION
Querying the /metrics endpoint causes:

```
fatal error: concurrent map read and map write

goroutine 169 [running]:
runtime.throw(0x75e912, 0x21)
	/home/travis/.gimme/versions/go1.7.linux.amd64/src/runtime/panic.go:566 +0x95 fp=0xc42067b8a0 sp=0xc42067b880
runtime.mapaccess2_faststr(0x6f18e0, 0xc420276c60, 0xc420764ac0, 0x1e, 0x2, 0xc420764ac0)
	/home/travis/.gimme/versions/go1.7.linux.amd64/src/runtime/hashmap_fast.go:306 +0x52b fp=0xc42067b900 sp=0xc42067b8a0
main.(*GaugeContainer).Fetch(0xc420144000, 0x756af7, 0xd, 0x75bdbb, 0x1b, 0xc420764a40, 0x2, 0x2, 0xc420012130, 0x417a5e)
	/home/travis/gopath/src/github.com/gettyimages/marathon_exporter/containers.go:63 +0xb2 fp=0xc42067b9f8 sp=0xc42067b900
main.(*Exporter).scrapeApps(0xc420127500, 0xc420360d10, 0xc4202d6360)
	/home/travis/gopath/src/github.com/gettyimages/marathon_exporter/exporter.go:142 +0x1eb fp=0xc42067bcd8 sp=0xc42067b9f8
main.(*Exporter).exportApps(0xc420127500, 0xc4202d6360, 0xc420276c90, 0x0)
	/home/travis/gopath/src/github.com/gettyimages/marathon_exporter/exporter.go:106 +0x1ed fp=0xc42067bd58 sp=0xc42067bcd8
main.(*Exporter).scrape(0xc420127500, 0xc4202d6360)
	/home/travis/gopath/src/github.com/gettyimages/marathon_exporter/exporter.go:77 +0x254 fp=0xc42067beb0 sp=0xc42067bd58
main.(*Exporter).Collect(0xc420127500, 0xc4202d6360)
	/home/travis/gopath/src/github.com/gettyimages/marathon_exporter/exporter.go:49 +0xd4 fp=0xc42067bf58 sp=0xc42067beb0
github.com/gettyimages/marathon_exporter/vendor/github.com/prometheus/client_golang/prometheus.(*registry).writePB.func2(0xc420330100, 0xc4202d6360, 0x8ba9c0, 0xc420127500)
	/home/travis/gopath/src/github.com/gettyimages/marathon_exporter/vendor/github.com/prometheus/client_golang/prometheus/registry.go:420 +0x63 fp=0xc42067bf80 sp=0xc42067bf58
runtime.goexit()
	/home/travis/.gimme/versions/go1.7.linux.amd64/src/runtime/asm_amd64.s:2086 +0x1 fp=0xc42067bf88 sp=0xc42067bf80
created by github.com/gettyimages/marathon_exporter/vendor/github.com/prometheus/client_golang/prometheus.(*registry).writePB
	/home/travis/gopath/src/github.com/gettyimages/marathon_exporter/vendor/github.com/prometheus/client_golang/prometheus/registry.go:421 +0x283

goroutine 1 [IO wait]:
net.runtime_pollWait(0x7f4b06bd3058, 0x72, 0x0)
	/home/travis/.gimme/versions/go1.7.linux.amd64/src/runtime/netpoll.go:160 +0x59
net.(*pollDesc).wait(0xc42054b870, 0x72, 0xc420048c28, 0xc420012190)
	/home/travis/.gimme/versions/go1.7.linux.amd64/src/net/fd_poll_runtime.go:73 +0x38
net.(*pollDesc).waitRead(0xc42054b870, 0x8b9b80, 0xc420012190)
	/home/travis/.gimme/versions/go1.7.linux.amd64/src/net/fd_poll_runtime.go:78 +0x34
net.(*netFD).accept(0xc42054b810, 0x0, 0x8b8700, 0xc420262000)
	/home/travis/.gimme/versions/go1.7.linux.amd64/src/net/fd_unix.go:419 +0x238
net.(*TCPListener).accept(0xc420572048, 0x29e8d60800, 0x0, 0x0)
	/home/travis/.gimme/versions/go1.7.linux.amd64/src/net/tcpsock_posix.go:132 +0x2e
net.(*TCPListener).AcceptTCP(0xc420572048, 0xc420048d50, 0xc420048d58, 0xc420048d48)
	/home/travis/.gimme/versions/go1.7.linux.amd64/src/net/tcpsock.go:209 +0x49
net/http.tcpKeepAliveListener.Accept(0xc420572048, 0x7804d8, 0xc420090080, 0x8bd080, 0xc420544510)
	/home/travis/.gimme/versions/go1.7.linux.amd64/src/net/http/server.go:2608 +0x2f
net/http.(*Server).Serve(0xc420142100, 0x8bcb00, 0xc420572048, 0x0, 0x0)
	/home/travis/.gimme/versions/go1.7.linux.amd64/src/net/http/server.go:2273 +0x1ce
net/http.(*Server).ListenAndServe(0xc420142100, 0xc420142100, 0x2)
	/home/travis/.gimme/versions/go1.7.linux.amd64/src/net/http/server.go:2219 +0xb4
net/http.ListenAndServe(0x7ffe0eca7b2c, 0x5, 0x0, 0x0, 0xc4205023c0, 0x416559)
	/home/travis/.gimme/versions/go1.7.linux.amd64/src/net/http/server.go:2351 +0xa0
main.main()
	/home/travis/gopath/src/github.com/gettyimages/marathon_exporter/main.go:101 +0x3d1

goroutine 34 [IO wait]:
net.runtime_pollWait(0x7f4b06bd3118, 0x72, 0x3)
	/home/travis/.gimme/versions/go1.7.linux.amd64/src/runtime/netpoll.go:160 +0x59
net.(*pollDesc).wait(0xc4201461b0, 0x72, 0xc4201339d0, 0xc420012190)
	/home/travis/.gimme/versions/go1.7.linux.amd64/src/net/fd_poll_runtime.go:73 +0x38
net.(*pollDesc).waitRead(0xc4201461b0, 0x8b9b80, 0xc420012190)
	/home/travis/.gimme/versions/go1.7.linux.amd64/src/net/fd_poll_runtime.go:78 +0x34
net.(*netFD).Read(0xc420146150, 0xc420150000, 0x1000, 0x1000, 0x0, 0x8b9b80, 0xc420012190)
	/home/travis/.gimme/versions/go1.7.linux.amd64/src/net/fd_unix.go:243 +0x1a1
net.(*conn).Read(0xc420148008, 0xc420150000, 0x1000, 0x1000, 0x0, 0x0, 0x0)
	/home/travis/.gimme/versions/go1.7.linux.amd64/src/net/net.go:173 +0x70
net/http.(*persistConn).Read(0xc4200ec800, 0xc420150000, 0x1000, 0x1000, 0x557ee0, 0xc420133b58, 0x40cc8d)
	/home/travis/.gimme/versions/go1.7.linux.amd64/src/net/http/transport.go:1256 +0x154
bufio.(*Reader).fill(0xc42013a240)
	/home/travis/.gimme/versions/go1.7.linux.amd64/src/bufio/bufio.go:97 +0x10c
bufio.(*Reader).Peek(0xc42013a240, 0x1, 0xc420133bbd, 0x1, 0x1, 0xc42013a2a0, 0x0)
	/home/travis/.gimme/versions/go1.7.linux.amd64/src/bufio/bufio.go:129 +0x62
net/http.(*persistConn).readLoop(0xc4200ec800)
	/home/travis/.gimme/versions/go1.7.linux.amd64/src/net/http/transport.go:1413 +0x1a1
created by net/http.(*Transport).dialConn
	/home/travis/.gimme/versions/go1.7.linux.amd64/src/net/http/transport.go:1057 +0x4e9

goroutine 35 [select]:
net/http.(*persistConn).writeLoop(0xc4200ec800)
	/home/travis/.gimme/versions/go1.7.linux.amd64/src/net/http/transport.go:1641 +0x3bd
created by net/http.(*Transport).dialConn
	/home/travis/.gimme/versions/go1.7.linux.amd64/src/net/http/transport.go:1058 +0x50e

goroutine 61 [select]:
net/http.(*persistConn).writeLoop(0xc4200ecf00)
	/home/travis/.gimme/versions/go1.7.linux.amd64/src/net/http/transport.go:1641 +0x3bd
created by net/http.(*Transport).dialConn
	/home/travis/.gimme/versions/go1.7.linux.amd64/src/net/http/transport.go:1058 +0x50e

goroutine 107 [select]:
net/http.(*persistConn).writeLoop(0xc4205dc800)
	/home/travis/.gimme/versions/go1.7.linux.amd64/src/net/http/transport.go:1641 +0x3bd
created by net/http.(*Transport).dialConn
	/home/travis/.gimme/versions/go1.7.linux.amd64/src/net/http/transport.go:1058 +0x50e

goroutine 58 [select]:
net/http.(*persistConn).writeLoop(0xc4205dcb00)
	/home/travis/.gimme/versions/go1.7.linux.amd64/src/net/http/transport.go:1641 +0x3bd
created by net/http.(*Transport).dialConn
	/home/travis/.gimme/versions/go1.7.linux.amd64/src/net/http/transport.go:1058 +0x50e

goroutine 49 [IO wait]:
net.runtime_pollWait(0x7f4b06bd2f98, 0x72, 0x5)
	/home/travis/.gimme/versions/go1.7.linux.amd64/src/runtime/netpoll.go:160 +0x59
net.(*pollDesc).wait(0xc420127790, 0x72, 0xc4200499d0, 0xc420012190)
	/home/travis/.gimme/versions/go1.7.linux.amd64/src/net/fd_poll_runtime.go:73 +0x38
net.(*pollDesc).waitRead(0xc420127790, 0x8b9b80, 0xc420012190)
	/home/travis/.gimme/versions/go1.7.linux.amd64/src/net/fd_poll_runtime.go:78 +0x34
net.(*netFD).Read(0xc420127730, 0xc420196000, 0x1000, 0x1000, 0x0, 0x8b9b80, 0xc420012190)
	/home/travis/.gimme/versions/go1.7.linux.amd64/src/net/fd_unix.go:243 +0x1a1
net.(*conn).Read(0xc42009a108, 0xc420196000, 0x1000, 0x1000, 0x0, 0x0, 0x0)
	/home/travis/.gimme/versions/go1.7.linux.amd64/src/net/net.go:173 +0x70
net/http.(*persistConn).Read(0xc4200ec900, 0xc420196000, 0x1000, 0x1000, 0x557ee0, 0xc420049b58, 0x40cc8d)
	/home/travis/.gimme/versions/go1.7.linux.amd64/src/net/http/transport.go:1256 +0x154
bufio.(*Reader).fill(0xc4200a7920)
	/home/travis/.gimme/versions/go1.7.linux.amd64/src/bufio/bufio.go:97 +0x10c
bufio.(*Reader).Peek(0xc4200a7920, 0x1, 0xc420049bbd, 0x1, 0x1, 0xc4200a7980, 0x0)
	/home/travis/.gimme/versions/go1.7.linux.amd64/src/bufio/bufio.go:129 +0x62
net/http.(*persistConn).readLoop(0xc4200ec900)
	/home/travis/.gimme/versions/go1.7.linux.amd64/src/net/http/transport.go:1413 +0x1a1
created by net/http.(*Transport).dialConn
	/home/travis/.gimme/versions/go1.7.linux.amd64/src/net/http/transport.go:1057 +0x4e9

goroutine 50 [select]:
net/http.(*persistConn).writeLoop(0xc4200ec900)
	/home/travis/.gimme/versions/go1.7.linux.amd64/src/net/http/transport.go:1641 +0x3bd
created by net/http.(*Transport).dialConn
	/home/travis/.gimme/versions/go1.7.linux.amd64/src/net/http/transport.go:1058 +0x50e

goroutine 9 [IO wait]:
net.runtime_pollWait(0x7f4b06bd2e18, 0x72, 0x8)
	/home/travis/.gimme/versions/go1.7.linux.amd64/src/runtime/netpoll.go:160 +0x59
net.(*pollDesc).wait(0xc42054b8e0, 0x72, 0xc4206e3790, 0xc420012190)
	/home/travis/.gimme/versions/go1.7.linux.amd64/src/net/fd_poll_runtime.go:73 +0x38
net.(*pollDesc).waitRead(0xc42054b8e0, 0x8b9b80, 0xc420012190)
	/home/travis/.gimme/versions/go1.7.linux.amd64/src/net/fd_poll_runtime.go:78 +0x34
net.(*netFD).Read(0xc42054b880, 0xc420560000, 0x1000, 0x1000, 0x0, 0x8b9b80, 0xc420012190)
	/home/travis/.gimme/versions/go1.7.linux.amd64/src/net/fd_unix.go:243 +0x1a1
net.(*conn).Read(0xc420572050, 0xc420560000, 0x1000, 0x1000, 0x0, 0x0, 0x0)
	/home/travis/.gimme/versions/go1.7.linux.amd64/src/net/net.go:173 +0x70
net/http.(*connReader).Read(0xc42043e5c0, 0xc420560000, 0x1000, 0x1000, 0xc42050bb00, 0x0, 0xc420034400)
	/home/travis/.gimme/versions/go1.7.linux.amd64/src/net/http/server.go:586 +0x144
bufio.(*Reader).fill(0xc420514300)
	/home/travis/.gimme/versions/go1.7.linux.amd64/src/bufio/bufio.go:97 +0x10c
bufio.(*Reader).ReadSlice(0xc420514300, 0xa, 0x0, 0x1e, 0xc4206e39b8, 0x33, 0x0)
	/home/travis/.gimme/versions/go1.7.linux.amd64/src/bufio/bufio.go:330 +0xb5
bufio.(*Reader).ReadLine(0xc420514300, 0xc4204e2000, 0xf0, 0xf0, 0x748d20, 0xc42050bb01, 0x17f4b06dce000)
	/home/travis/.gimme/versions/go1.7.linux.amd64/src/bufio/bufio.go:359 +0x37
net/textproto.(*Reader).readLineSlice(0xc4207300c0, 0xc4206e3a88, 0xc4206e3a88, 0x418288, 0xf0, 0x748d20)
	/home/travis/.gimme/versions/go1.7.linux.amd64/src/net/textproto/reader.go:55 +0x5e
net/textproto.(*Reader).ReadLine(0xc4207300c0, 0xc4204e2000, 0xc41ffd7a6f, 0xc4206e3b50, 0x417a5e)
	/home/travis/.gimme/versions/go1.7.linux.amd64/src/net/textproto/reader.go:36 +0x2f
net/http.readRequest(0xc420514300, 0x0, 0xc4204e2000, 0x0, 0x0)
	/home/travis/.gimme/versions/go1.7.linux.amd64/src/net/http/request.go:793 +0xa5
net/http.(*conn).readRequest(0xc420142480, 0x8bcfc0, 0xc420548f00, 0x0, 0x0, 0x0)
	/home/travis/.gimme/versions/go1.7.linux.amd64/src/net/http/server.go:765 +0x10d
net/http.(*conn).serve(0xc420142480, 0x8bcfc0, 0xc420548f00)
	/home/travis/.gimme/versions/go1.7.linux.amd64/src/net/http/server.go:1532 +0x3d3
created by net/http.(*Server).Serve
	/home/travis/.gimme/versions/go1.7.linux.amd64/src/net/http/server.go:2293 +0x44d

goroutine 42 [IO wait]:
net.runtime_pollWait(0x7f4b06bd2ed8, 0x72, 0x6)
	/home/travis/.gimme/versions/go1.7.linux.amd64/src/runtime/netpoll.go:160 +0x59
net.(*pollDesc).wait(0xc420146a70, 0x72, 0xc4200479d0, 0xc420012190)
	/home/travis/.gimme/versions/go1.7.linux.amd64/src/net/fd_poll_runtime.go:73 +0x38
net.(*pollDesc).waitRead(0xc420146a70, 0x8b9b80, 0xc420012190)
	/home/travis/.gimme/versions/go1.7.linux.amd64/src/net/fd_poll_runtime.go:78 +0x34
net.(*netFD).Read(0xc420146a10, 0xc420286000, 0x1000, 0x1000, 0x0, 0x8b9b80, 0xc420012190)
	/home/travis/.gimme/versions/go1.7.linux.amd64/src/net/fd_unix.go:243 +0x1a1
net.(*conn).Read(0xc420148048, 0xc420286000, 0x1000, 0x1000, 0x0, 0x0, 0x0)
	/home/travis/.gimme/versions/go1.7.linux.amd64/src/net/net.go:173 +0x70
net/http.(*persistConn).Read(0xc4201e8500, 0xc420286000, 0x1000, 0x1000, 0x557ee0, 0xc420047b58, 0x40cc8d)
	/home/travis/.gimme/versions/go1.7.linux.amd64/src/net/http/transport.go:1256 +0x154
bufio.(*Reader).fill(0xc42013aea0)
	/home/travis/.gimme/versions/go1.7.linux.amd64/src/bufio/bufio.go:97 +0x10c
bufio.(*Reader).Peek(0xc42013aea0, 0x1, 0xc420047bbd, 0x1, 0x1, 0xc42013af00, 0x0)
	/home/travis/.gimme/versions/go1.7.linux.amd64/src/bufio/bufio.go:129 +0x62
net/http.(*persistConn).readLoop(0xc4201e8500)
	/home/travis/.gimme/versions/go1.7.linux.amd64/src/net/http/transport.go:1413 +0x1a1
created by net/http.(*Transport).dialConn
	/home/travis/.gimme/versions/go1.7.linux.amd64/src/net/http/transport.go:1057 +0x4e9

goroutine 43 [select]:
net/http.(*persistConn).writeLoop(0xc4201e8500)
	/home/travis/.gimme/versions/go1.7.linux.amd64/src/net/http/transport.go:1641 +0x3bd
created by net/http.(*Transport).dialConn
	/home/travis/.gimme/versions/go1.7.linux.amd64/src/net/http/transport.go:1058 +0x50e

goroutine 106 [IO wait]:
net.runtime_pollWait(0x7f4b06bd2bd8, 0x72, 0xa)
	/home/travis/.gimme/versions/go1.7.linux.amd64/src/runtime/netpoll.go:160 +0x59
net.(*pollDesc).wait(0xc42029a0d0, 0x72, 0xc4203cb9d0, 0xc420012190)
	/home/travis/.gimme/versions/go1.7.linux.amd64/src/net/fd_poll_runtime.go:73 +0x38
net.(*pollDesc).waitRead(0xc42029a0d0, 0x8b9b80, 0xc420012190)
	/home/travis/.gimme/versions/go1.7.linux.amd64/src/net/fd_poll_runtime.go:78 +0x34
net.(*netFD).Read(0xc42029a070, 0xc42015c000, 0x1000, 0x1000, 0x0, 0x8b9b80, 0xc420012190)
	/home/travis/.gimme/versions/go1.7.linux.amd64/src/net/fd_unix.go:243 +0x1a1
net.(*conn).Read(0xc420506060, 0xc42015c000, 0x1000, 0x1000, 0x0, 0x0, 0x0)
	/home/travis/.gimme/versions/go1.7.linux.amd64/src/net/net.go:173 +0x70
net/http.(*persistConn).Read(0xc4205dc800, 0xc42015c000, 0x1000, 0x1000, 0x557ee0, 0xc4203cbb58, 0x40cc8d)
	/home/travis/.gimme/versions/go1.7.linux.amd64/src/net/http/transport.go:1256 +0x154
bufio.(*Reader).fill(0xc4203bfa40)
	/home/travis/.gimme/versions/go1.7.linux.amd64/src/bufio/bufio.go:97 +0x10c
bufio.(*Reader).Peek(0xc4203bfa40, 0x1, 0xc4203cbbbd, 0x1, 0x1, 0xc4203bfda0, 0x0)
	/home/travis/.gimme/versions/go1.7.linux.amd64/src/bufio/bufio.go:129 +0x62
net/http.(*persistConn).readLoop(0xc4205dc800)
	/home/travis/.gimme/versions/go1.7.linux.amd64/src/net/http/transport.go:1413 +0x1a1
created by net/http.(*Transport).dialConn
	/home/travis/.gimme/versions/go1.7.linux.amd64/src/net/http/transport.go:1057 +0x4e9

goroutine 57 [IO wait]:
net.runtime_pollWait(0x7f4b06bd2a58, 0x72, 0xc)
	/home/travis/.gimme/versions/go1.7.linux.amd64/src/runtime/netpoll.go:160 +0x59
net.(*pollDesc).wait(0xc42038b3a0, 0x72, 0xc42004c9d0, 0xc420012190)
	/home/travis/.gimme/versions/go1.7.linux.amd64/src/net/fd_poll_runtime.go:73 +0x38
net.(*pollDesc).waitRead(0xc42038b3a0, 0x8b9b80, 0xc420012190)
	/home/travis/.gimme/versions/go1.7.linux.amd64/src/net/fd_poll_runtime.go:78 +0x34
net.(*netFD).Read(0xc42038b340, 0xc420374000, 0x1000, 0x1000, 0x0, 0x8b9b80, 0xc420012190)
	/home/travis/.gimme/versions/go1.7.linux.amd64/src/net/fd_unix.go:243 +0x1a1
net.(*conn).Read(0xc42009bd20, 0xc420374000, 0x1000, 0x1000, 0x0, 0x0, 0x0)
	/home/travis/.gimme/versions/go1.7.linux.amd64/src/net/net.go:173 +0x70
net/http.(*persistConn).Read(0xc4205dcb00, 0xc420374000, 0x1000, 0x1000, 0x557ee0, 0xc42004cb58, 0x40cc8d)
	/home/travis/.gimme/versions/go1.7.linux.amd64/src/net/http/transport.go:1256 +0x154
bufio.(*Reader).fill(0xc4202990e0)
	/home/travis/.gimme/versions/go1.7.linux.amd64/src/bufio/bufio.go:97 +0x10c
bufio.(*Reader).Peek(0xc4202990e0, 0x1, 0xc42004cbbd, 0x1, 0x1, 0xc420299440, 0x0)
	/home/travis/.gimme/versions/go1.7.linux.amd64/src/bufio/bufio.go:129 +0x62
net/http.(*persistConn).readLoop(0xc4205dcb00)
	/home/travis/.gimme/versions/go1.7.linux.amd64/src/net/http/transport.go:1413 +0x1a1
created by net/http.(*Transport).dialConn
	/home/travis/.gimme/versions/go1.7.linux.amd64/src/net/http/transport.go:1057 +0x4e9

goroutine 60 [IO wait]:
net.runtime_pollWait(0x7f4b06bd2b18, 0x72, 0xd)
	/home/travis/.gimme/versions/go1.7.linux.amd64/src/runtime/netpoll.go:160 +0x59
net.(*pollDesc).wait(0xc42038bb80, 0x72, 0xc4207c39d0, 0xc420012190)
	/home/travis/.gimme/versions/go1.7.linux.amd64/src/net/fd_poll_runtime.go:73 +0x38
net.(*pollDesc).waitRead(0xc42038bb80, 0x8b9b80, 0xc420012190)
	/home/travis/.gimme/versions/go1.7.linux.amd64/src/net/fd_poll_runtime.go:78 +0x34
net.(*netFD).Read(0xc42038bb20, 0xc4207c8000, 0x1000, 0x1000, 0x0, 0x8b9b80, 0xc420012190)
	/home/travis/.gimme/versions/go1.7.linux.amd64/src/net/fd_unix.go:243 +0x1a1
net.(*conn).Read(0xc42009bd40, 0xc4207c8000, 0x1000, 0x1000, 0x0, 0x0, 0x0)
	/home/travis/.gimme/versions/go1.7.linux.amd64/src/net/net.go:173 +0x70
net/http.(*persistConn).Read(0xc4200ecf00, 0xc4207c8000, 0x1000, 0x1000, 0x557ee0, 0xc4207c3b58, 0x40cc8d)
	/home/travis/.gimme/versions/go1.7.linux.amd64/src/net/http/transport.go:1256 +0x154
bufio.(*Reader).fill(0xc4202940c0)
	/home/travis/.gimme/versions/go1.7.linux.amd64/src/bufio/bufio.go:97 +0x10c
bufio.(*Reader).Peek(0xc4202940c0, 0x1, 0xc4207c3bbd, 0x1, 0x1, 0xc420294300, 0x0)
	/home/travis/.gimme/versions/go1.7.linux.amd64/src/bufio/bufio.go:129 +0x62
net/http.(*persistConn).readLoop(0xc4200ecf00)
	/home/travis/.gimme/versions/go1.7.linux.amd64/src/net/http/transport.go:1413 +0x1a1
created by net/http.(*Transport).dialConn
	/home/travis/.gimme/versions/go1.7.linux.amd64/src/net/http/transport.go:1057 +0x4e9

goroutine 98 [IO wait]:
net.runtime_pollWait(0x7f4b06bd2c98, 0x72, 0x9)
	/home/travis/.gimme/versions/go1.7.linux.amd64/src/runtime/netpoll.go:160 +0x59
net.(*pollDesc).wait(0xc4202ca610, 0x72, 0xc42004d9d0, 0xc420012190)
	/home/travis/.gimme/versions/go1.7.linux.amd64/src/net/fd_poll_runtime.go:73 +0x38
net.(*pollDesc).waitRead(0xc4202ca610, 0x8b9b80, 0xc420012190)
	/home/travis/.gimme/versions/go1.7.linux.amd64/src/net/fd_poll_runtime.go:78 +0x34
net.(*netFD).Read(0xc4202ca5b0, 0xc4203d8000, 0x1000, 0x1000, 0x0, 0x8b9b80, 0xc420012190)
	/home/travis/.gimme/versions/go1.7.linux.amd64/src/net/fd_unix.go:243 +0x1a1
net.(*conn).Read(0xc420506028, 0xc4203d8000, 0x1000, 0x1000, 0x0, 0x0, 0x0)
	/home/travis/.gimme/versions/go1.7.linux.amd64/src/net/net.go:173 +0x70
net/http.(*persistConn).Read(0xc4200ec700, 0xc4203d8000, 0x1000, 0x1000, 0x557ee0, 0xc42004db58, 0x40cc8d)
	/home/travis/.gimme/versions/go1.7.linux.amd64/src/net/http/transport.go:1256 +0x154
bufio.(*Reader).fill(0xc42049b4a0)
	/home/travis/.gimme/versions/go1.7.linux.amd64/src/bufio/bufio.go:97 +0x10c
bufio.(*Reader).Peek(0xc42049b4a0, 0x1, 0xc42004dbbd, 0x1, 0x1, 0xc42049b800, 0x0)
	/home/travis/.gimme/versions/go1.7.linux.amd64/src/bufio/bufio.go:129 +0x62
net/http.(*persistConn).readLoop(0xc4200ec700)
	/home/travis/.gimme/versions/go1.7.linux.amd64/src/net/http/transport.go:1413 +0x1a1
created by net/http.(*Transport).dialConn
	/home/travis/.gimme/versions/go1.7.linux.amd64/src/net/http/transport.go:1057 +0x4e9

goroutine 99 [select]:
net/http.(*persistConn).writeLoop(0xc4200ec700)
	/home/travis/.gimme/versions/go1.7.linux.amd64/src/net/http/transport.go:1641 +0x3bd
created by net/http.(*Transport).dialConn
	/home/travis/.gimme/versions/go1.7.linux.amd64/src/net/http/transport.go:1058 +0x50e

goroutine 119 [chan receive]:
github.com/gettyimages/marathon_exporter/vendor/github.com/prometheus/client_golang/prometheus.(*registry).writePB(0xc4200a65a0, 0x8b8fc0, 0xc42040c0a0, 0x0, 0x0)
	/home/travis/gopath/src/github.com/gettyimages/marathon_exporter/vendor/github.com/prometheus/client_golang/prometheus/registry.go:432 +0x321
github.com/gettyimages/marathon_exporter/vendor/github.com/prometheus/client_golang/prometheus.(*registry).ServeHTTP(0xc4200a65a0, 0x8bc240, 0xc420572458, 0xc4201021e0)
	/home/travis/gopath/src/github.com/gettyimages/marathon_exporter/vendor/github.com/prometheus/client_golang/prometheus/registry.go:380 +0x13b
net/http.(Handler).ServeHTTP-fm(0x8bc240, 0xc420572458, 0xc4201021e0)
	/home/travis/gopath/src/github.com/gettyimages/marathon_exporter/vendor/github.com/prometheus/client_golang/prometheus/http.go:79 +0x4d
github.com/gettyimages/marathon_exporter/vendor/github.com/prometheus/client_golang/prometheus.InstrumentHandlerFuncWithOpts.func1(0x8bc780, 0xc4202b2000, 0xc4201021e0)
	/home/travis/gopath/src/github.com/gettyimages/marathon_exporter/vendor/github.com/prometheus/client_golang/prometheus/http.go:178 +0x2ab
net/http.HandlerFunc.ServeHTTP(0xc42000d180, 0x8bc780, 0xc4202b2000, 0xc4201021e0)
	/home/travis/.gimme/versions/go1.7.linux.amd64/src/net/http/server.go:1726 +0x44
net/http.(*ServeMux).ServeHTTP(0x8d8de0, 0x8bc780, 0xc4202b2000, 0xc4201021e0)
	/home/travis/.gimme/versions/go1.7.linux.amd64/src/net/http/server.go:2022 +0x7f
net/http.serverHandler.ServeHTTP(0xc420142100, 0x8bc780, 0xc4202b2000, 0xc4201021e0)
	/home/travis/.gimme/versions/go1.7.linux.amd64/src/net/http/server.go:2202 +0x7d
net/http.(*conn).serve(0xc4202cc000, 0x8bcfc0, 0xc4201a2100)
	/home/travis/.gimme/versions/go1.7.linux.amd64/src/net/http/server.go:1579 +0x4b7
created by net/http.(*Server).Serve
	/home/travis/.gimme/versions/go1.7.linux.amd64/src/net/http/server.go:2293 +0x44d

goroutine 120 [chan send]:
github.com/gettyimages/marathon_exporter/vendor/github.com/prometheus/client_golang/prometheus.computeApproximateRequestSize(0xc4201021e0, 0xc420770ae0, 0x13)
	/home/travis/gopath/src/github.com/gettyimages/marathon_exporter/vendor/github.com/prometheus/client_golang/prometheus/http.go:207 +0x151
created by github.com/gettyimages/marathon_exporter/vendor/github.com/prometheus/client_golang/prometheus.InstrumentHandlerFuncWithOpts.func1
	/home/travis/gopath/src/github.com/gettyimages/marathon_exporter/vendor/github.com/prometheus/client_golang/prometheus/http.go:166 +0x16a

goroutine 121 [semacquire]:
sync.runtime_Semacquire(0xc42036020c)
	/home/travis/.gimme/versions/go1.7.linux.amd64/src/runtime/sema.go:47 +0x30
sync.(*WaitGroup).Wait(0xc420360200)
	/home/travis/.gimme/versions/go1.7.linux.amd64/src/sync/waitgroup.go:131 +0x97
github.com/gettyimages/marathon_exporter/vendor/github.com/prometheus/client_golang/prometheus.(*registry).writePB.func1(0xc420360200, 0xc420770b40)
	/home/travis/gopath/src/github.com/gettyimages/marathon_exporter/vendor/github.com/prometheus/client_golang/prometheus/registry.go:414 +0x2d
created by github.com/gettyimages/marathon_exporter/vendor/github.com/prometheus/client_golang/prometheus.(*registry).writePB
	/home/travis/gopath/src/github.com/gettyimages/marathon_exporter/vendor/github.com/prometheus/client_golang/prometheus/registry.go:416 +0x1db

goroutine 122 [runnable]:
github.com/gettyimages/marathon_exporter/vendor/github.com/prometheus/client_golang/prometheus.NewDesc(0xc420bcdc20, 0x4e, 0xc420500ea0, 0x5f, 0x0, 0x0, 0x0, 0x0, 0x6da760)
	/home/travis/gopath/src/github.com/gettyimages/marathon_exporter/vendor/github.com/prometheus/client_golang/prometheus/desc.go:152 +0xc6b
github.com/gettyimages/marathon_exporter/vendor/github.com/prometheus/client_golang/prometheus.NewGaugeVec(0x755110, 0x8, 0x0, 0x0, 0xc420bcda40, 0x45, 0xc420500ea0, 0x5f, 0x0, 0x0, ...)
	/home/travis/gopath/src/github.com/gettyimages/marathon_exporter/vendor/github.com/prometheus/client_golang/prometheus/gauge.go:73 +0xd3
main.(*GaugeContainer).Fetch(0xc420144000, 0xc420bcda40, 0x45, 0xc420500ea0, 0x5f, 0x0, 0x0, 0x0, 0xc42094a450, 0xc420bbb701)
	/home/travis/gopath/src/github.com/gettyimages/marathon_exporter/containers.go:70 +0x1cb
main.(*Exporter).scrapeTimer(0xc420127500, 0xc420b3ceb0, 0x41, 0xc420bb5f00, 0x1, 0x0, 0x0)
	/home/travis/gopath/src/github.com/gettyimages/marathon_exporter/exporter.go:391 +0x663
main.(*Exporter).scrapeTimers(0xc420127500, 0xc420919f50)
	/home/travis/gopath/src/github.com/gettyimages/marathon_exporter/exporter.go:364 +0xd6
main.(*Exporter).scrapeMetrics(0xc420127500, 0xc420534090, 0xc420770b40)
	/home/travis/gopath/src/github.com/gettyimages/marathon_exporter/exporter.go:206 +0x158
main.(*Exporter).exportMetrics(0xc420127500, 0xc420770b40, 0x0, 0x0)
	/home/travis/gopath/src/github.com/gettyimages/marathon_exporter/exporter.go:123 +0x1ed
main.(*Exporter).scrape(0xc420127500, 0xc420770b40)
	/home/travis/gopath/src/github.com/gettyimages/marathon_exporter/exporter.go:80 +0x292
main.(*Exporter).Collect(0xc420127500, 0xc420770b40)
	/home/travis/gopath/src/github.com/gettyimages/marathon_exporter/exporter.go:49 +0xd4
github.com/gettyimages/marathon_exporter/vendor/github.com/prometheus/client_golang/prometheus.(*registry).writePB.func2(0xc420360200, 0xc420770b40, 0x8ba9c0, 0xc420127500)
	/home/travis/gopath/src/github.com/gettyimages/marathon_exporter/vendor/github.com/prometheus/client_golang/prometheus/registry.go:420 +0x63
created by github.com/gettyimages/marathon_exporter/vendor/github.com/prometheus/client_golang/prometheus.(*registry).writePB
	/home/travis/gopath/src/github.com/gettyimages/marathon_exporter/vendor/github.com/prometheus/client_golang/prometheus/registry.go:421 +0x283

goroutine 135 [IO wait]:
net.runtime_pollWait(0x7f4b06bd28d8, 0x72, 0xf)
	/home/travis/.gimme/versions/go1.7.linux.amd64/src/runtime/netpoll.go:160 +0x59
net.(*pollDesc).wait(0xc4202c8990, 0x72, 0xc4207bf9d0, 0xc420012190)
	/home/travis/.gimme/versions/go1.7.linux.amd64/src/net/fd_poll_runtime.go:73 +0x38
net.(*pollDesc).waitRead(0xc4202c8990, 0x8b9b80, 0xc420012190)
	/home/travis/.gimme/versions/go1.7.linux.amd64/src/net/fd_poll_runtime.go:78 +0x34
net.(*netFD).Read(0xc4202c8930, 0xc4201a4000, 0x1000, 0x1000, 0x0, 0x8b9b80, 0xc420012190)
	/home/travis/.gimme/versions/go1.7.linux.amd64/src/net/fd_unix.go:243 +0x1a1
net.(*conn).Read(0xc420032048, 0xc4201a4000, 0x1000, 0x1000, 0x0, 0x0, 0x0)
	/home/travis/.gimme/versions/go1.7.linux.amd64/src/net/net.go:173 +0x70
net/http.(*persistConn).Read(0xc4205dc000, 0xc4201a4000, 0x1000, 0x1000, 0x557ee0, 0xc4207bfb58, 0x40cc8d)
	/home/travis/.gimme/versions/go1.7.linux.amd64/src/net/http/transport.go:1256 +0x154
bufio.(*Reader).fill(0xc420771440)
	/home/travis/.gimme/versions/go1.7.linux.amd64/src/bufio/bufio.go:97 +0x10c
bufio.(*Reader).Peek(0xc420771440, 0x1, 0xc4207bfbbd, 0x1, 0x1, 0xc4207714a0, 0x0)
	/home/travis/.gimme/versions/go1.7.linux.amd64/src/bufio/bufio.go:129 +0x62
net/http.(*persistConn).readLoop(0xc4205dc000)
	/home/travis/.gimme/versions/go1.7.linux.amd64/src/net/http/transport.go:1413 +0x1a1
created by net/http.(*Transport).dialConn
	/home/travis/.gimme/versions/go1.7.linux.amd64/src/net/http/transport.go:1057 +0x4e9

goroutine 136 [select]:
net/http.(*persistConn).writeLoop(0xc4205dc000)
	/home/travis/.gimme/versions/go1.7.linux.amd64/src/net/http/transport.go:1641 +0x3bd
created by net/http.(*Transport).dialConn
	/home/travis/.gimme/versions/go1.7.linux.amd64/src/net/http/transport.go:1058 +0x50e

goroutine 89 [IO wait]:
net.runtime_pollWait(0x7f4b06bd2d58, 0x72, 0xb)
	/home/travis/.gimme/versions/go1.7.linux.amd64/src/runtime/netpoll.go:160 +0x59
net.(*pollDesc).wait(0xc420218610, 0x72, 0xc4207c29d0, 0xc420012190)
	/home/travis/.gimme/versions/go1.7.linux.amd64/src/net/fd_poll_runtime.go:73 +0x38
net.(*pollDesc).waitRead(0xc420218610, 0x8b9b80, 0xc420012190)
	/home/travis/.gimme/versions/go1.7.linux.amd64/src/net/fd_poll_runtime.go:78 +0x34
net.(*netFD).Read(0xc4202185b0, 0xc42052a000, 0x1000, 0x1000, 0x0, 0x8b9b80, 0xc420012190)
	/home/travis/.gimme/versions/go1.7.linux.amd64/src/net/fd_unix.go:243 +0x1a1
net.(*conn).Read(0xc4207c64f0, 0xc42052a000, 0x1000, 0x1000, 0x0, 0x0, 0x0)
	/home/travis/.gimme/versions/go1.7.linux.amd64/src/net/net.go:173 +0x70
net/http.(*persistConn).Read(0xc4200ed000, 0xc42052a000, 0x1000, 0x1000, 0x557ee0, 0xc4207c2b58, 0x40cc8d)
	/home/travis/.gimme/versions/go1.7.linux.amd64/src/net/http/transport.go:1256 +0x154
bufio.(*Reader).fill(0xc420256180)
	/home/travis/.gimme/versions/go1.7.linux.amd64/src/bufio/bufio.go:97 +0x10c
bufio.(*Reader).Peek(0xc420256180, 0x1, 0xc4207c2bbd, 0x1, 0x1, 0xc4202561e0, 0x0)
	/home/travis/.gimme/versions/go1.7.linux.amd64/src/bufio/bufio.go:129 +0x62
net/http.(*persistConn).readLoop(0xc4200ed000)
	/home/travis/.gimme/versions/go1.7.linux.amd64/src/net/http/transport.go:1413 +0x1a1
created by net/http.(*Transport).dialConn
	/home/travis/.gimme/versions/go1.7.linux.amd64/src/net/http/transport.go:1057 +0x4e9

goroutine 90 [select]:
net/http.(*persistConn).writeLoop(0xc4200ed000)
	/home/travis/.gimme/versions/go1.7.linux.amd64/src/net/http/transport.go:1641 +0x3bd
created by net/http.(*Transport).dialConn
	/home/travis/.gimme/versions/go1.7.linux.amd64/src/net/http/transport.go:1058 +0x50e

goroutine 161 [chan receive]:
github.com/gettyimages/marathon_exporter/vendor/github.com/prometheus/client_golang/prometheus.(*registry).writePB(0xc4200a65a0, 0x8b8fc0, 0xc4202620a0, 0x0, 0x0)
	/home/travis/gopath/src/github.com/gettyimages/marathon_exporter/vendor/github.com/prometheus/client_golang/prometheus/registry.go:432 +0x321
github.com/gettyimages/marathon_exporter/vendor/github.com/prometheus/client_golang/prometheus.(*registry).ServeHTTP(0xc4200a65a0, 0x8bc240, 0xc42009a008, 0xc4201024b0)
	/home/travis/gopath/src/github.com/gettyimages/marathon_exporter/vendor/github.com/prometheus/client_golang/prometheus/registry.go:380 +0x13b
net/http.(Handler).ServeHTTP-fm(0x8bc240, 0xc42009a008, 0xc4201024b0)
	/home/travis/gopath/src/github.com/gettyimages/marathon_exporter/vendor/github.com/prometheus/client_golang/prometheus/http.go:79 +0x4d
github.com/gettyimages/marathon_exporter/vendor/github.com/prometheus/client_golang/prometheus.InstrumentHandlerFuncWithOpts.func1(0x8bc780, 0xc420866000, 0xc4201024b0)
	/home/travis/gopath/src/github.com/gettyimages/marathon_exporter/vendor/github.com/prometheus/client_golang/prometheus/http.go:178 +0x2ab
net/http.HandlerFunc.ServeHTTP(0xc42000d180, 0x8bc780, 0xc420866000, 0xc4201024b0)
	/home/travis/.gimme/versions/go1.7.linux.amd64/src/net/http/server.go:1726 +0x44
net/http.(*ServeMux).ServeHTTP(0x8d8de0, 0x8bc780, 0xc420866000, 0xc4201024b0)
	/home/travis/.gimme/versions/go1.7.linux.amd64/src/net/http/server.go:2022 +0x7f
net/http.serverHandler.ServeHTTP(0xc420142100, 0x8bc780, 0xc420866000, 0xc4201024b0)
	/home/travis/.gimme/versions/go1.7.linux.amd64/src/net/http/server.go:2202 +0x7d
net/http.(*conn).serve(0xc420090080, 0x8bcfc0, 0xc4204b2100)
	/home/travis/.gimme/versions/go1.7.linux.amd64/src/net/http/server.go:1579 +0x4b7
created by net/http.(*Server).Serve
	/home/travis/.gimme/versions/go1.7.linux.amd64/src/net/http/server.go:2293 +0x44d

goroutine 162 [chan send]:
github.com/gettyimages/marathon_exporter/vendor/github.com/prometheus/client_golang/prometheus.computeApproximateRequestSize(0xc4201024b0, 0xc4202d6300, 0x13)
	/home/travis/gopath/src/github.com/gettyimages/marathon_exporter/vendor/github.com/prometheus/client_golang/prometheus/http.go:207 +0x151
created by github.com/gettyimages/marathon_exporter/vendor/github.com/prometheus/client_golang/prometheus.InstrumentHandlerFuncWithOpts.func1
	/home/travis/gopath/src/github.com/gettyimages/marathon_exporter/vendor/github.com/prometheus/client_golang/prometheus/http.go:166 +0x16a

goroutine 163 [semacquire]:
sync.runtime_Semacquire(0xc42033010c)
	/home/travis/.gimme/versions/go1.7.linux.amd64/src/runtime/sema.go:47 +0x30
sync.(*WaitGroup).Wait(0xc420330100)
	/home/travis/.gimme/versions/go1.7.linux.amd64/src/sync/waitgroup.go:131 +0x97
github.com/gettyimages/marathon_exporter/vendor/github.com/prometheus/client_golang/prometheus.(*registry).writePB.func1(0xc420330100, 0xc4202d6360)
	/home/travis/gopath/src/github.com/gettyimages/marathon_exporter/vendor/github.com/prometheus/client_golang/prometheus/registry.go:414 +0x2d
created by github.com/gettyimages/marathon_exporter/vendor/github.com/prometheus/client_golang/prometheus.(*registry).writePB
	/home/travis/gopath/src/github.com/gettyimages/marathon_exporter/vendor/github.com/prometheus/client_golang/prometheus/registry.go:416 +0x1db

goroutine 109 [IO wait]:
net.runtime_pollWait(0x7f4b06bd2758, 0x72, 0x11)
	/home/travis/.gimme/versions/go1.7.linux.amd64/src/runtime/netpoll.go:160 +0x59
net.(*pollDesc).wait(0xc42036a1b0, 0x72, 0xc4201319d0, 0xc420012190)
	/home/travis/.gimme/versions/go1.7.linux.amd64/src/net/fd_poll_runtime.go:73 +0x38
net.(*pollDesc).waitRead(0xc42036a1b0, 0x8b9b80, 0xc420012190)
	/home/travis/.gimme/versions/go1.7.linux.amd64/src/net/fd_poll_runtime.go:78 +0x34
net.(*netFD).Read(0xc42036a150, 0xc420738000, 0x1000, 0x1000, 0x0, 0x8b9b80, 0xc420012190)
	/home/travis/.gimme/versions/go1.7.linux.amd64/src/net/fd_unix.go:243 +0x1a1
net.(*conn).Read(0xc42054e008, 0xc420738000, 0x1000, 0x1000, 0x0, 0x0, 0x0)
	/home/travis/.gimme/versions/go1.7.linux.amd64/src/net/net.go:173 +0x70
net/http.(*persistConn).Read(0xc4205dc100, 0xc420738000, 0x1000, 0x1000, 0x557ee0, 0xc420131b58, 0x40cc8d)
	/home/travis/.gimme/versions/go1.7.linux.amd64/src/net/http/transport.go:1256 +0x154
bufio.(*Reader).fill(0xc420294240)
	/home/travis/.gimme/versions/go1.7.linux.amd64/src/bufio/bufio.go:97 +0x10c
bufio.(*Reader).Peek(0xc420294240, 0x1, 0xc420131bbd, 0x1, 0x1, 0xc4202942a0, 0x0)
	/home/travis/.gimme/versions/go1.7.linux.amd64/src/bufio/bufio.go:129 +0x62
net/http.(*persistConn).readLoop(0xc4205dc100)
	/home/travis/.gimme/versions/go1.7.linux.amd64/src/net/http/transport.go:1413 +0x1a1
created by net/http.(*Transport).dialConn
	/home/travis/.gimme/versions/go1.7.linux.amd64/src/net/http/transport.go:1057 +0x4e9

goroutine 110 [select]:
net/http.(*persistConn).writeLoop(0xc4205dc100)
	/home/travis/.gimme/versions/go1.7.linux.amd64/src/net/http/transport.go:1641 +0x3bd
created by net/http.(*Transport).dialConn
	/home/travis/.gimme/versions/go1.7.linux.amd64/src/net/http/transport.go:1058 +0x50e
```

This is not good.

This commit fixes the problem.