### PR TITLE
try and read MARATHON_USERNAME and MARATHON_PASSWORD for auth info

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,4 +40,7 @@ Usage of marathon_exporter:
         If set use a syslog logger or JSON logging. Example: logger:syslog?appname=bob&local=7 or logger:stdout?json=true. Defaults to stderr.
   -log.level value
         Only log messages with the given severity or above. Valid levels: [debug, info, warn, error, fatal]. (default info)
+
+Environmental Variables
+ - MARATHON_USERNAME and MARATHON_PASSWORD may be supplied for auth
 ```


### PR DESCRIPTION
It seems easier to use [env vars paired with k8s secrets](https://kubernetes.io/docs/concepts/configuration/secret/#using-secrets-as-environment-variables) rather than [looping through cli flags](https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#use-environment-variables-to-define-arguments).

The existing flags are still supported. 