### PR TITLE
add -app.labels to optionally scrape an app's labels

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,6 +8,7 @@ test:
 	go test -v -run=$(RUN) $(TEST)
 
 build: clean
+	go fmt ./...
 	go build -v -o bin/$(TARGET)
 
 release: clean

--- a/README.md
+++ b/README.md
@@ -32,6 +32,8 @@ bin/marathon_exporter --help
 Usage of marathon_exporter:
   -marathon.uri string
         URI of Marathon (default "http://marathon.mesos:8080")
+  -app.labels string
+        Comma separated list of labels to scrape from each app
   -web.listen-address string
         Address to listen on for web interface and telemetry. (default ":9088")
   -web.telemetry-path string

--- a/exporter_test.go
+++ b/exporter_test.go
@@ -31,7 +31,7 @@ func (s *testScraper) Scrape(path string) ([]byte, error) {
 }
 
 func newTestExporter(namespace string) *testExporter {
-	exporter := NewExporter(&testScraper{`{}`}, namespace)
+	exporter := NewExporter(&testScraper{`{}`}, namespace, nil)
 
 	prometheus.MustRegister(exporter)
 	server := httptest.NewServer(prometheus.UninstrumentedHandler())
@@ -72,7 +72,7 @@ func getFunctionName() string {
 }
 
 func export(json string) ([]byte, error) {
-	exporter := NewExporter(&testScraper{json}, "marathon")
+	exporter := NewExporter(&testScraper{json}, "marathon", nil)
 	prometheus.MustRegister(exporter)
 	defer prometheus.Unregister(exporter)
 

--- a/main.go
+++ b/main.go
@@ -6,6 +6,7 @@ import (
 	"net"
 	"net/http"
 	"net/url"
+	"strings"
 	"time"
 
 	"github.com/matt-deboer/go-marathon"
@@ -25,6 +26,10 @@ var (
 	marathonUri = flag.String(
 		"marathon.uri", "http://marathon.mesos:8080",
 		"URI of Marathon")
+
+	labelsToScrape = flag.String(
+		"app.labels", "",
+		"Labels to scrape from each app")
 )
 
 func marathonConnect(uri *url.URL) error {
@@ -83,7 +88,8 @@ func main() {
 		time.Sleep(retryTimeout)
 	}
 
-	exporter := NewExporter(&scraper{uri}, defaultNamespace)
+	labels := strings.Split(*labelsToScrape, ",")
+	exporter := NewExporter(&scraper{uri}, defaultNamespace, labels)
 	prometheus.MustRegister(exporter)
 
 	http.Handle(*metricsPath, prometheus.Handler())


### PR DESCRIPTION
We use an app label `team` internally for alert routing. 

