### PR TITLE
Support marathon 1.5+

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,8 @@ A [Prometheus](http://prometheus.io) metrics exporter for the [Marathon](https:/
 
 This exporter exposes Marathon's Codahale/Dropwizard metrics via its `/metrics` endpoint. To learn more, visit the [Marathon metrics doc](http://mesosphere.github.io/marathon/docs/metrics.html).
 
+Note: version v1.5.1+ of this exporter is not compatible with marathon 1.4.0 and below.
+
 ## Getting
 
 ```sh

--- a/exporter.go
+++ b/exporter.go
@@ -251,7 +251,7 @@ func (e *Exporter) scrapeGauges(json *gabs.Container) {
 }
 
 func (e *Exporter) scrapeGauge(key string, json *gabs.Container) (bool, error) {
-	data := json.Path("value").Data()
+	data := json.Path("max").Data()
 	value, ok := data.(float64)
 	if !ok {
 		return false, errors.New(fmt.Sprintf("Bad conversion! Unexpected value \"%v\" for gauge %s\n", data, key))

--- a/exporter_test.go
+++ b/exporter_test.go
@@ -173,8 +173,8 @@ func Test_export_gauges(t *testing.T) {
 
 	results, err := te.export(`{
 		"gauges": {
-			"foo_value": {"value": 1},
-			"bar_value": {"value": 2}
+            "foo_value": {"min": 0, "max": 1},
+            "bar_value": {"min": 0, "max": 2}
 		}
 	}`)
 
@@ -188,8 +188,8 @@ func Test_export_gauges(t *testing.T) {
 
 	results, err = te.export(`{
 		"gauges": {
-			"foo_value": {"value": 1},
-			"baz_value": {"value": 3}
+            "foo_value": {"min": 0, "max": 1},
+            "baz_value": {"min": 0, "max": 3}
 		}
 	}`)
 


### PR DESCRIPTION
In marathon 1.5, metric collection have been switched to kamon library.
Gauge implementation in kamon is:

> Our Gauge is a mix between the Histogram and the MinMaxCounter, taking
>measurements of a given value every 100 milliseconds by default and
> storing the observed values in a Histogram.
(http://kamon.io/documentation/0.6.x/kamon-core/metrics/instruments/)

Since kamon metrics are "flushed" every 10 seconds, using max (or min)
of the kamon gauge gives one observed value of the gauge.

This patch makes this exporter not compatible with marathon 1.5+

Upstream ticket (https://jira.mesosphere.com/browse/MARATHON-7673) has
not been fixed yet, it seems reasonnable to assume this will stay like
this.