### PR TITLE
Docker multi-stage build with fixed go version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,16 @@
-FROM scratch
-MAINTAINER Getty Images "https://github.com/gettyimages"
+FROM golang:1.9-alpine3.7 as builder
+RUN apk add --update \
+    make \
+    git \
+  && rm -rf /var/cache/apk/*
+RUN mkdir -p /go/src/github.com/gettyimages/marathon_exporter
+ADD . /go/src/github.com/gettyimages/marathon_exporter
+WORKDIR /go/src/github.com/gettyimages/marathon_exporter
+RUN make build
 
-ADD bin/marathon_exporter /marathon_exporter
+FROM alpine:3.7
+
+COPY --from=builder /go/src/github.com/gettyimages/marathon_exporter/bin/marathon_exporter /marathon_exporter
 ENTRYPOINT ["/marathon_exporter"]
 
 EXPOSE 9088

--- a/Makefile
+++ b/Makefile
@@ -8,13 +8,12 @@ test:
 	go test -v -run=$(RUN) $(TEST)
 
 build: clean
-	go build -v -o bin/$(TARGET)
-
-release: clean
 	CGO_ENABLED=0 GOARCH=amd64 GOOS=linux go build \
 		-a -tags netgo \
 		-ldflags "-X main.Version=$(VERSION)" \
 		-o bin/$(TARGET) .
+
+release: build
 	docker build -t gettyimages/$(TARGET):$(VERSION) .
 
 publish: release
@@ -24,3 +23,9 @@ publish: release
 
 clean:
 	rm -rf bin/
+
+image:
+	docker build -t $(TARGET) .
+
+shell:
+	docker run -it --entrypoint /bin/ash $(TARGET)

--- a/README.md
+++ b/README.md
@@ -19,11 +19,11 @@ $ go get github.com/gettyimages/marathon_exporter
 $ docker pull gettyimages/marathon_exporter
 ```
 
-*\-or-*
+*\-or-* locally build image:
 
 ```
-make deps && make
-bin/marathon_exporter --help
+make image
+docker run -it marathon_exporter --help
 ```
 
 ## Using


### PR DESCRIPTION
Switch base image to Alpine Linux that is more standard distribution which resolves issues like missing `/bin/sh` command:
```
container_linux.go:247: starting container process caused "exec: \"/bin/sh\": stat /bin/sh: no such file or directory"
docker: Error response from daemon: oci runtime error: container_linux.go:247: starting container process caused "exec: \"/bin/sh\": stat /bin/sh: no such file or directory".
```
Two stage build is used that easily allow either fixing code on specific Go version or upgrading to a newer release without dependency on development environment.

Resulting image contains only base Alpine Linux plus `marathon_exporter` binary (together around `13MB`).