### PR TITLE
Fix export of Gauges in Marathon newer versions

### DIFF
--- a/exporter.go
+++ b/exporter.go
@@ -251,10 +251,13 @@ func (e *Exporter) scrapeGauges(json *gabs.Container) {
 }
 
 func (e *Exporter) scrapeGauge(key string, json *gabs.Container) (bool, error) {
-	data := json.Path("max").Data()
-	value, ok := data.(float64)
+	value, ok := json.Path("value").Data().(float64)
 	if !ok {
-		return false, errors.New(fmt.Sprintf("Bad conversion! Unexpected value \"%v\" for gauge %s\n", data, key))
+		// Let's try to scrap old min,max metric
+		value, ok = json.Path("max").Data().(float64)
+		if !ok {
+			return false, errors.New(fmt.Sprintf("Bad conversion! Unexpected value for 'value' or 'max' in gauge %s\n", key))
+		}
 	}
 
 	name := renameMetric(key)

--- a/exporter_test.go
+++ b/exporter_test.go
@@ -174,6 +174,7 @@ func Test_export_gauges(t *testing.T) {
 	results, err := te.export(`{
 		"gauges": {
             "foo_value": {"min": 0, "max": 1},
+            "qux_value": {"value": 4},
             "bar_value": {"min": 0, "max": 2}
 		}
 	}`)
@@ -184,6 +185,7 @@ func Test_export_gauges(t *testing.T) {
 
 	assertResultsContain(t, results,
 		fName+"_foo_value 1",
+		fName+"_qux_value 4",
 		fName+"_bar_value 2")
 
 	results, err = te.export(`{
@@ -203,6 +205,7 @@ func Test_export_gauges(t *testing.T) {
 
 	assertResultsDoNotContain(t, results,
 		fName+"_bar_value 2")
+
 }
 
 func Test_export_meters(t *testing.T) {


### PR DESCRIPTION
This was not working at least in marathon 1.8, because gauges are now
providing a single "value" instead of "min" and "max" values.